### PR TITLE
Add Zed IDE paths to ide_extension_surface BOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **[ai_surface](collection/ai_surface/)**     | Maps AI tooling on Windows developer endpoints and highlights their configuration artifacts that may expose server definitions, commands, arguments, and embedded credentials. |
 | **[clipboard_grab](collection/clipboard_grab/)**       | Retrieves text data from the Windows clipboard using Win32 APIs and returns the contents to the callback.  Original Code Credits: [@rvrsh3ll](https://github.com/rvrsh3ll/BOF_Collection) |
-| **[ide_extension_surface](collection/ide_extension_surface/)** | Enumerates VS Code, Cursor, Windsurf, Insiders, OSS, and server/remote extension manifests from per-user profile roots and summarizes extension identity, activation events, and capability signals. |
+| **[ide_extension_surface](collection/ide_extension_surface/)** | Enumerates VS Code, Cursor, Windsurf, Zed, Insiders, OSS, and server/remote extension manifests from per-user profile roots and summarizes extension identity, activation events, and capability signals. |
 | **[powershell_history](collection/powershell_history/)** | Collects PowerShell history artifacts from default PSReadLine and transcript locations. Useful for locating credentials or infrastructure. |
 | **[window_handles_enum](collection/window_handles_enum/)**  | Enumerates window handles across all system processes and uses a legitimate window handle to access the clipboard.                                                      |
 

--- a/collection/ide_extension_surface/README.md
+++ b/collection/ide_extension_surface/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Enumerates installed IDE extension manifests for VS Code, Cursor, Windsurf, Insiders, OSS, and server/remote profiles from per-user roots and summarizes extension identity, activation events, and capability signals.
+Enumerates installed IDE extension manifests for VS Code, Cursor, Windsurf, Zed, Insiders, OSS, and server/remote profiles from per-user roots and summarizes extension identity, activation events, and capability signals.
 
 Supported roots:
 
@@ -12,6 +12,7 @@ Supported roots:
 - `%USERPROFILE%\.cursor\extensions`
 - `%USERPROFILE%\.windsurf\extensions`
 - `%USERPROFILE%\.codeium\windsurf\extensions`
+- `%LOCALAPPDATA%\Zed\extensions\installed`
 - `%USERPROFILE%\.vscode-server\extensions`
 - `%USERPROFILE%\.cursor-server\extensions`
 - `%USERPROFILE%\.vscode-remote\extensions`

--- a/collection/ide_extension_surface/ide_extension_surface.c
+++ b/collection/ide_extension_surface/ide_extension_surface.c
@@ -639,6 +639,78 @@ static void summarize_capabilities(const char *json, char *out, size_t out_size)
     }
 }
 
+static int extract_toml_string_value(const char *toml, const char *key, char *out, size_t out_size) {
+    char pattern[FIELD_SMALL];
+    const char *match;
+    char quote;
+    size_t i = 0;
+
+    if (!toml || !key || !out || out_size == 0) {
+        return 0;
+    }
+
+    inline_memset(pattern, 0, sizeof(pattern));
+    if (!append_ascii_fragment(pattern, sizeof(pattern), key) ||
+        !append_ascii_fragment(pattern, sizeof(pattern), " = \"")) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    match = ascii_find(toml, pattern);
+    if (!match) {
+        inline_memset(pattern, 0, sizeof(pattern));
+        if (!append_ascii_fragment(pattern, sizeof(pattern), key) ||
+            !append_ascii_fragment(pattern, sizeof(pattern), " = '")) {
+            out[0] = '\0';
+            return 0;
+        }
+        match = ascii_find(toml, pattern);
+        if (!match) {
+            out[0] = '\0';
+            return 0;
+        }
+        quote = '\'';
+    } else {
+        quote = '"';
+    }
+
+    match += inline_strlen(pattern);
+    while (*match && i + 1 < out_size) {
+        if (*match == quote) {
+            break;
+        }
+        out[i++] = *match++;
+    }
+    out[i] = '\0';
+    return i > 0;
+}
+
+static void summarize_zed_capabilities(const char *toml, char *out, size_t out_size) {
+    if (!toml || !out || out_size == 0) {
+        return;
+    }
+    out[0] = '\0';
+
+    if (ascii_find(toml, "languages/") || ascii_find(toml, "[languages]")) {
+        append_capability_label(out, out_size, "languages");
+    }
+    if (ascii_find(toml, "themes/") || ascii_find(toml, "[themes]")) {
+        append_capability_label(out, out_size, "themes");
+    }
+    if (ascii_find(toml, "snippets/") || ascii_find(toml, "[snippets]")) {
+        append_capability_label(out, out_size, "snippets");
+    }
+    if (ascii_find(toml, "[debuggers]") || ascii_find(toml, "debuggers/")) {
+        append_capability_label(out, out_size, "debuggers");
+    }
+    if (ascii_find(toml, "Cargo.toml") || ascii_find(toml, "src/lib.rs")) {
+        append_capability_label(out, out_size, "wasm");
+    }
+    if (ascii_contains_ci(toml, "mcp") || ascii_contains_ci(toml, "modelcontextprotocol")) {
+        append_capability_label(out, out_size, "mcp-adjacent");
+    }
+}
+
 static void build_extension_id(const char *publisher, const char *name, char *out, size_t out_size) {
     if (!out || out_size == 0) {
         return;
@@ -726,16 +798,64 @@ static void report_manifest(const wchar_t *editor_label, const wchar_t *resolved
     results->manifests_found++;
 }
 
-static void scan_extension_root(const wchar_t *editor_label, const wchar_t *pattern, scan_results_t *results) {
+static void report_zed_manifest(const wchar_t *editor_label, const wchar_t *resolved_root, const wchar_t *manifest_path, const char *toml, int was_truncated, scan_results_t *results) {
+    char display_name[FIELD_MEDIUM];
+    char version[FIELD_SMALL];
+    char extension_id[FIELD_MEDIUM];
+    char description[FIELD_LARGE];
+    char capabilities[FIELD_LARGE];
+
+    if (!editor_label || !resolved_root || !manifest_path || !toml || !results) {
+        return;
+    }
+
+    inline_memset(display_name, 0, sizeof(display_name));
+    inline_memset(version, 0, sizeof(version));
+    inline_memset(extension_id, 0, sizeof(extension_id));
+    inline_memset(description, 0, sizeof(description));
+    inline_memset(capabilities, 0, sizeof(capabilities));
+
+    extract_toml_string_value(toml, "id", extension_id, sizeof(extension_id));
+    extract_toml_string_value(toml, "name", display_name, sizeof(display_name));
+    extract_toml_string_value(toml, "version", version, sizeof(version));
+    extract_toml_string_value(toml, "description", description, sizeof(description));
+    summarize_zed_capabilities(toml, capabilities, sizeof(capabilities));
+
+    print_root_header_if_needed(results, editor_label, resolved_root);
+    BeaconPrintf(CALLBACK_OUTPUT, "[+] Manifest: %S\n", manifest_path);
+    if (extension_id[0] != '\0') {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   ID: %s\n", extension_id);
+    }
+    if (display_name[0] != '\0') {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   Display Name: %s\n", display_name);
+    }
+    if (version[0] != '\0') {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   Version: %s\n", version);
+    }
+    if (description[0] != '\0') {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   Description: %s\n", description);
+    }
+    if (capabilities[0] != '\0') {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   Capabilities: %s\n", capabilities);
+    }
+    if (was_truncated) {
+        BeaconPrintf(CALLBACK_OUTPUT, "[i]   Note: extension.toml truncated at %d bytes\n", MAX_FILE_READ);
+    }
+
+    results->manifests_found++;
+}
+
+static void scan_extension_root(const wchar_t *editor_label, const wchar_t *pattern, const wchar_t *manifest_name, int is_toml, scan_results_t *results) {
     wchar_t root[MAX_PATH_LEN];
     wchar_t search[MAX_PATH_LEN];
     wchar_t child_dir[MAX_PATH_LEN];
+    wchar_t manifest_leaf[MAX_PATH_LEN];
     wchar_t manifest_path[MAX_PATH_LEN];
     WIN32_FIND_DATAW fd;
     HANDLE hFind = INVALID_HANDLE_VALUE;
     DWORD needed;
 
-    if (!editor_label || !pattern || !results) {
+    if (!editor_label || !pattern || !manifest_name || !results) {
         return;
     }
 
@@ -769,10 +889,12 @@ static void scan_extension_root(const wchar_t *editor_label, const wchar_t *patt
         }
 
         inline_memset(child_dir, 0, sizeof(child_dir));
+        inline_memset(manifest_leaf, 0, sizeof(manifest_leaf));
         inline_memset(manifest_path, 0, sizeof(manifest_path));
         if (!build_path(root, L"\\", child_dir, MAX_PATH_LEN) ||
             !append_wide_in_place(child_dir, fd.cFileName, MAX_PATH_LEN) ||
-            !build_path(child_dir, L"\\package.json", manifest_path, MAX_PATH_LEN)) {
+            !build_path(L"\\", manifest_name, manifest_leaf, MAX_PATH_LEN) ||
+            !build_path(child_dir, manifest_leaf, manifest_path, MAX_PATH_LEN)) {
             continue;
         }
         if (!path_exists(manifest_path)) {
@@ -782,7 +904,11 @@ static void scan_extension_root(const wchar_t *editor_label, const wchar_t *patt
             continue;
         }
 
-        report_manifest(editor_label, root, manifest_path, buffer, was_truncated, results);
+        if (is_toml) {
+            report_zed_manifest(editor_label, root, manifest_path, buffer, was_truncated, results);
+        } else {
+            report_manifest(editor_label, root, manifest_path, buffer, was_truncated, results);
+        }
         KERNEL32$VirtualFree(buffer, 0, MEM_RELEASE);
     } while (KERNEL32$FindNextFileW(hFind, &fd));
 
@@ -798,15 +924,16 @@ void go(char *args, unsigned long alen) {
 
     BeaconPrintf(CALLBACK_OUTPUT, SECTION_IDE_EXTENSIONS ":\n");
 
-    scan_extension_root(L"VS Code", L"%USERPROFILE%\\.vscode\\extensions", &results);
-    scan_extension_root(L"VS Code Insiders", L"%USERPROFILE%\\.vscode-insiders\\extensions", &results);
-    scan_extension_root(L"VS Code OSS", L"%USERPROFILE%\\.vscode-oss\\extensions", &results);
-    scan_extension_root(L"Cursor", L"%USERPROFILE%\\.cursor\\extensions", &results);
-    scan_extension_root(L"Windsurf", L"%USERPROFILE%\\.windsurf\\extensions", &results);
-    scan_extension_root(L"Windsurf (Codeium root)", L"%USERPROFILE%\\.codeium\\windsurf\\extensions", &results);
-    scan_extension_root(L"VS Code Server", L"%USERPROFILE%\\.vscode-server\\extensions", &results);
-    scan_extension_root(L"Cursor Server", L"%USERPROFILE%\\.cursor-server\\extensions", &results);
-    scan_extension_root(L"VS Code Remote", L"%USERPROFILE%\\.vscode-remote\\extensions", &results);
+    scan_extension_root(L"VS Code", L"%USERPROFILE%\\.vscode\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"VS Code Insiders", L"%USERPROFILE%\\.vscode-insiders\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"VS Code OSS", L"%USERPROFILE%\\.vscode-oss\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"Cursor", L"%USERPROFILE%\\.cursor\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"Windsurf", L"%USERPROFILE%\\.windsurf\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"Windsurf (Codeium root)", L"%USERPROFILE%\\.codeium\\windsurf\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"Zed", L"%LOCALAPPDATA%\\Zed\\extensions\\installed", L"extension.toml", 1, &results);
+    scan_extension_root(L"VS Code Server", L"%USERPROFILE%\\.vscode-server\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"Cursor Server", L"%USERPROFILE%\\.cursor-server\\extensions", L"package.json", 0, &results);
+    scan_extension_root(L"VS Code Remote", L"%USERPROFILE%\\.vscode-remote\\extensions", L"package.json", 0, &results);
 
     if (results.manifests_found == 0) {
         BeaconPrintf(CALLBACK_OUTPUT, "[i] Not detected\n");

--- a/collection/ide_extension_surface/metadata.json
+++ b/collection/ide_extension_surface/metadata.json
@@ -1,5 +1,5 @@
 {
   "name": "ide_extension_surface",
   "category": "collection",
-  "description": "Enumerates VS Code, Cursor, Windsurf, Insiders, OSS, and server/remote extension manifests from per-user profile roots and summarizes extension identity, activation events, and capability signals."
+  "description": "Enumerates VS Code, Cursor, Windsurf, Zed, Insiders, OSS, and server/remote extension manifests from per-user profile roots and summarizes extension identity, activation events, and capability signals."
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Zed IDE extension enumeration to the `ide_extension_surface` BOF.

- Scans `%LOCALAPPDATA%\Zed\extensions\installed` for installed Zed extensions
- Parses `extension.toml` manifests (Zed's native format) for ID, name, version, description, and capability signals
- Updates README and metadata to document Zed support

## Why

Zed stores extensions under `%LOCALAPPDATA%\Zed\extensions\installed` with `extension.toml` manifests rather than VS Code-style `package.json` files. Without this path and TOML parsing, the BOF would miss Zed entirely on Windows endpoints.

## Testing

- Source changes compile cleanly per linter checks
- Cross-compiler (`x86_64-w64-mingw32-gcc`) was unavailable in the cloud environment; rebuild the `.x64.o` artifact locally with `make` in `collection/ide_extension_surface/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eecc1-2ad3-79e1-b1b8-561d8318f7c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eecc1-2ad3-79e1-b1b8-561d8318f7c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

